### PR TITLE
feat(trace-replay): send X-Session-ID for consistent_hash routing

### DIFF
--- a/trace_replay_tester.py
+++ b/trace_replay_tester.py
@@ -1651,7 +1651,8 @@ class APIClient:
     async def send_request(self, messages: List[dict], max_tokens: int, stream: bool = True,
                            on_first_token: Optional[callable] = None,
                            on_chunk: Optional[callable] = None,
-                           tokenizer=None) -> dict:
+                           tokenizer=None,
+                           session_id: Optional[str] = None) -> dict:
         """
         Send request and return metrics.
 
@@ -1660,6 +1661,9 @@ class APIClient:
             max_tokens: Maximum tokens to generate
             stream: Whether to use streaming (default True)
             on_first_token: Optional callback invoked when first token arrives (prefill complete)
+            session_id: Optional session identifier sent as the X-Session-ID header. Enables
+                the vLLM Router's consistent_hash policy to pin all requests of a session to
+                the same worker, maximizing KV-cache reuse.
 
         Returns dict with: response_text, ttft, ttlt, actual_output_tokens, error_type,
                           start_time, first_token_time, complete_time (absolute timestamps),
@@ -1674,6 +1678,8 @@ class APIClient:
 
         try:
             params = self._build_request_params(messages, max_tokens, stream)
+            if session_id is not None:
+                params["extra_headers"] = {"X-Session-ID": session_id}
 
             if stream:
                 response = await self.client.chat.completions.create(**params)
@@ -2561,7 +2567,8 @@ class TestOrchestrator:
                 stream=stream,
                 on_first_token=on_first_token,
                 on_chunk=on_chunk,
-                tokenizer=self.generator.tokenizer
+                tokenizer=self.generator.tokenizer,
+                session_id=user.trace_id
             )
 
             # Decrement decode counter if first token was received


### PR DESCRIPTION
## Summary

Adds `X-Session-ID` session affinity to the trace replay tester so it can drive
the vLLM Router's `consistent_hash` load-balancing policy.

`APIClient.send_request` now accepts an optional `session_id` and, when set,
emits it as the `X-Session-ID` HTTP header on the chat completion request. The
call site passes `user.trace_id`, so every request of a session carries a stable
identifier the router can hash on.

## Why

The router's `consistent_hash` policy extracts a routing key using a hash-key
priority list in which `X-Session-ID` is the highest-priority key. Sending it
keeps all turns of a conversation on the same worker, maximizing KV-cache reuse
for multi-turn workloads. Without the header, the router falls back to lower
priority keys (or a body hash) and cannot reliably pin a conversation to a
worker.

## Behavior

- Header is sent only when a `session_id` is provided; otherwise the request is
  unchanged (no header), preserving existing behavior.
- Parent conversations and each sub-agent use their own `trace_id` as the
  session id. This gives every session its own per-worker affinity while letting
  concurrently running sub-agents spread across workers instead of hotspotting a
  single one.

## Changes

- `APIClient.send_request`: new optional `session_id` parameter; sets
  `extra_headers={"X-Session-ID": session_id}` when provided.
- Replay call site: passes `session_id=user.trace_id`.

## Testing

- Verified that requests carry `X-Session-ID: <trace_id>` when a session id is
  set, and that the header is absent when it is not.

## References

- https://github.com/vllm-project/vllm/pull/44663
- https://github.com/vllm-project/router/blob/main/docs/load_balancing/README.md#hash-key-priority